### PR TITLE
remove tests for :Name COMMAND

### DIFF
--- a/tester/command/nick.cpp
+++ b/tester/command/nick.cpp
@@ -67,14 +67,4 @@ void	test_nick_cmd(server *server)
 	std::cout <<  CYAN << "Test 4: Erroneous nick\n" << RESET;
 	std::cout << YELLOW << "NICK @rr*bˆ\n" << RESET;
 	cmd::nick(*server, 2, "@rr*bˆ");
-
-/* still don't know if we are implementing this	
-	std::cout << "Test 4: Nick change\n" << RESET;
-	std::cout << YELLOW << ":Wiz NICK Kilroy\n" << RESET;
-	cmd::nick(*server, 1, ":Wiz NICK Kilroy");
-	
-	std::cout << "Test 5: Bad nick\n" << RESET;
-	std::cout << YELLOW << ":Kilroy NICK *)=.&&&\n" << RESET;
-	cmd::nick(*server, 1, ":Kilroy NICK *)=.&&&");
-*/
 }


### PR DESCRIPTION
In the examples below, some messages appear using the full format:

   :Name COMMAND parameter list

   Such examples represent a message from "Name" in transit between
   servers, where it is essential to include the name of the original
   sender of the message so remote servers may send back a reply along
   the correct path.